### PR TITLE
fix: persist trackedSeconds on session to survive screenshot cleanup

### DIFF
--- a/packages/server/drizzle/0005_add_tracked_seconds.sql
+++ b/packages/server/drizzle/0005_add_tracked_seconds.sql
@@ -1,0 +1,14 @@
+ALTER TABLE "sessions" ADD COLUMN "tracked_seconds" integer;
+
+-- Backfill: for completed/stopped sessions that have confirmed screenshots,
+-- compute from screenshots. For those without screenshots (cleaned up),
+-- use totalActiveSeconds as best approximation.
+UPDATE sessions SET tracked_seconds = COALESCE(
+  (SELECT GREATEST(0, (count(distinct s.minute_bucket) - 1) * 60)
+   FROM screenshots s
+   WHERE s.session_id = sessions.id AND s.confirmed = true
+   HAVING count(distinct s.minute_bucket) > 0),
+  total_active_seconds
+)
+WHERE status IN ('stopped', 'compiling', 'complete', 'failed')
+  AND tracked_seconds IS NULL;

--- a/packages/server/drizzle/meta/0005_snapshot.json
+++ b/packages/server/drizzle/meta/0005_snapshot.json
@@ -1,0 +1,370 @@
+{
+  "id": "3d9e0ca7-b917-4138-b425-37f966023124",
+  "prevId": "4229b3e1-18e6-4d9b-b7d2-913281410ac1",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.screenshots": {
+      "name": "screenshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "r2_key": {
+          "name": "r2_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_at": {
+          "name": "requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "minute_bucket": {
+          "name": "minute_bucket",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confirmed": {
+          "name": "confirmed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_size_bytes": {
+          "name": "file_size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sampled": {
+          "name": "sampled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_screenshots_session_id": {
+          "name": "idx_screenshots_session_id",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_screenshots_session_bucket": {
+          "name": "idx_screenshots_session_bucket",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "minute_bucket",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_screenshots_unconfirmed": {
+          "name": "idx_screenshots_unconfirmed",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "confirmed = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "screenshots_session_id_sessions_id_fk": {
+          "name": "screenshots_session_id_sessions_id_fk",
+          "tableFrom": "screenshots",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "status": {
+          "name": "status",
+          "type": "session_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stopped_at": {
+          "name": "stopped_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paused_at": {
+          "name": "paused_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_screenshot_at": {
+          "name": "last_screenshot_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resumed_at": {
+          "name": "resumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_active_seconds": {
+          "name": "total_active_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "tracked_seconds": {
+          "name": "tracked_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "video_url": {
+          "name": "video_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "video_r2_key": {
+          "name": "video_r2_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "video_webm_url": {
+          "name": "video_webm_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "video_webm_r2_key": {
+          "name": "video_webm_r2_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail_url": {
+          "name": "thumbnail_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail_r2_key": {
+          "name": "thumbnail_r2_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "compile_attempts": {
+          "name": "compile_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_sessions_status": {
+          "name": "idx_sessions_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sessions_active_last_screenshot": {
+          "name": "idx_sessions_active_last_screenshot",
+          "columns": [
+            {
+              "expression": "last_screenshot_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "status IN ('active', 'paused', 'pending')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.session_status": {
+      "name": "session_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "active",
+        "paused",
+        "stopped",
+        "compiling",
+        "complete",
+        "failed"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/server/drizzle/meta/_journal.json
+++ b/packages/server/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1775530929501,
       "tag": "0004_round_roxanne_simpson",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1776508800000,
+      "tag": "0005_add_tracked_seconds",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -48,6 +48,7 @@ export const sessions = pgTable(
     lastScreenshotAt: timestamp("last_screenshot_at", { withTimezone: true }),
     resumedAt: timestamp("resumed_at", { withTimezone: true }),
     totalActiveSeconds: integer("total_active_seconds").notNull().default(0),
+    trackedSeconds: integer("tracked_seconds"),
     videoUrl: text("video_url"),
     videoR2Key: text("video_r2_key"),
     videoWebmUrl: text("video_webm_url"),

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -22,9 +22,11 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 
 const app = Fastify({ logger: true });
 
+const IS_DEV = process.env.NODE_ENV !== "production";
+
 await app.register(cors, {
   origin: (origin, cb) => {
-    // Allow: no origin (server-to-server), *.hackclub.com, localhost dev, tauri app
+    // Allow: no origin (server-to-server), *.hackclub.com, tauri app
     // Tauri uses tauri:// on macOS/Linux but http://tauri.localhost on Windows
     if (
       !origin ||
@@ -36,10 +38,13 @@ await app.register(cors, {
     }
     try {
       const hostname = new URL(origin).hostname;
-      if (
+      const isAllowed =
         /\.hackclub\.com$/.test(hostname) ||
-        /^https?:\/\/localhost(:\d+)?$/.test(origin)
-      ) {
+        hostname === "hackclub.com" ||
+        // Only allow localhost origins in development
+        (IS_DEV && /^https?:\/\/localhost(:\d+)?$/.test(origin));
+
+      if (isAllowed) {
         cb(null, true);
       } else {
         app.log.warn(`CORS rejected origin: ${origin}`);

--- a/packages/server/src/lib/timeouts.ts
+++ b/packages/server/src/lib/timeouts.ts
@@ -1,6 +1,7 @@
 import { sql, eq, and, lt, isNotNull, inArray } from "drizzle-orm";
 import { DeleteObjectCommand } from "@aws-sdk/client-s3";
 import { db, schema } from "../db/index.js";
+import { r2Client, R2_BUCKET } from "../config/r2.js";
 import {
   boss,
   COMPILE_JOB,
@@ -8,7 +9,6 @@ import {
   CLEANUP_UNCONFIRMED_JOB,
   CLEANUP_SCREENSHOTS_JOB,
 } from "./queue.js";
-import { r2Client, R2_BUCKET } from "../config/r2.js";
 import { cleanupRateLimits } from "./timing.js";
 import {
   AUTO_PAUSE_AFTER_MINUTES,
@@ -114,12 +114,27 @@ async function checkTimeouts() {
       );
     }
 
+    // Compute tracked seconds before stopping (screenshots may be cleaned up later)
+    const [{ buckets }] = await db
+      .select({
+        buckets: sql<number>`count(distinct ${schema.screenshots.minuteBucket})`,
+      })
+      .from(schema.screenshots)
+      .where(
+        and(
+          eq(schema.screenshots.sessionId, session.id),
+          eq(schema.screenshots.confirmed, true),
+        ),
+      );
+    const trackedSeconds = Math.max(0, (Number(buckets) - 1) * 60);
+
     await db
       .update(schema.sessions)
       .set({
         status: "stopped",
         stoppedAt: now,
         totalActiveSeconds,
+        trackedSeconds,
         updatedAt: now,
       })
       .where(eq(schema.sessions.id, session.id));
@@ -197,18 +212,39 @@ async function cleanupUnconfirmed() {
     Date.now() - UNCONFIRMED_CLEANUP_AFTER_MINUTES * 60_000,
   );
 
-  // Delete unconfirmed screenshot records older than threshold
-  await db
-    .delete(schema.screenshots)
+  // Find unconfirmed screenshot records older than threshold
+  const stale = await db
+    .select({ id: schema.screenshots.id, r2Key: schema.screenshots.r2Key })
+    .from(schema.screenshots)
     .where(
       and(
         eq(schema.screenshots.confirmed, false),
         lt(schema.screenshots.createdAt, threshold),
       ),
     );
-  // Note: orphaned R2 objects from unconfirmed uploads will naturally
-  // be cleaned up as they were never confirmed. The presigned URLs
-  // have expired so no new uploads can happen to those keys.
+
+  // Delete orphaned R2 objects to prevent storage abuse
+  for (const ss of stale) {
+    try {
+      await r2Client.send(
+        new DeleteObjectCommand({ Bucket: R2_BUCKET, Key: ss.r2Key }),
+      );
+    } catch {
+      // Non-fatal: object may not exist if upload never completed
+    }
+  }
+
+  // Delete the database records
+  if (stale.length > 0) {
+    await db
+      .delete(schema.screenshots)
+      .where(
+        and(
+          eq(schema.screenshots.confirmed, false),
+          lt(schema.screenshots.createdAt, threshold),
+        ),
+      );
+  }
 }
 
 async function cleanupCompletedScreenshots() {

--- a/packages/server/src/routes/internal.ts
+++ b/packages/server/src/routes/internal.ts
@@ -89,6 +89,7 @@ export async function internalRoutes(app: FastifyInstance) {
       // Exclude internal R2 storage keys and build proper media URLs
       const baseUrl = process.env.BASE_URL || "http://localhost:3000";
       const { videoR2Key, thumbnailR2Key, videoWebmR2Key, ...sessionData } = session;
+      const liveTrackedSeconds = Math.max(0, (Number(count) - 1) * 60);
       return {
         session: {
           ...sessionData,
@@ -102,7 +103,7 @@ export async function internalRoutes(app: FastifyInstance) {
             ? `${baseUrl}/api/media/${session.id}/video.webm`
             : null,
         },
-        trackedSeconds: Math.max(0, (Number(count) - 1) * 60),
+        trackedSeconds: session.trackedSeconds ?? liveTrackedSeconds,
         screenshotCount: Number(count),
       };
     },
@@ -178,12 +179,27 @@ export async function internalRoutes(app: FastifyInstance) {
         );
       }
 
+      // Compute tracked seconds before stopping
+      const [{ buckets }] = await db
+        .select({
+          buckets: sql<number>`count(distinct ${schema.screenshots.minuteBucket})`,
+        })
+        .from(schema.screenshots)
+        .where(
+          and(
+            eq(schema.screenshots.sessionId, sessionId),
+            eq(schema.screenshots.confirmed, true),
+          ),
+        );
+      const trackedSeconds = Math.max(0, (Number(buckets) - 1) * 60);
+
       const [updated] = await db
         .update(schema.sessions)
         .set({
           status: "stopped",
           stoppedAt: new Date(),
           totalActiveSeconds,
+          trackedSeconds,
           updatedAt: new Date(),
         })
         .where(and(

--- a/packages/server/src/routes/sessions.ts
+++ b/packages/server/src/routes/sessions.ts
@@ -100,8 +100,10 @@ export async function sessionRoutes(app: FastifyInstance) {
       const session = await findSession(request.params.token);
       if (!session) return reply.code(404).send({ error: "Session not found" });
 
-      const trackedSeconds = await getTrackedSeconds(session.id);
+      const liveTrackedSeconds = await getTrackedSeconds(session.id);
       const screenshotCount = await getScreenshotCount(session.id);
+      // Prefer stored value (survives screenshot cleanup), fall back to live count
+      const trackedSeconds = session.trackedSeconds ?? liveTrackedSeconds;
 
       const baseUrl = process.env.BASE_URL || "http://localhost:3000";
       return {
@@ -249,6 +251,7 @@ export async function sessionRoutes(app: FastifyInstance) {
       // Generate presigned PUT URL
       // Note: Don't set ContentLength — it signs an exact size and rejects
       // anything different. Size is validated at confirmation via HeadObject.
+      // Orphaned uploads are cleaned up by the unconfirmed cleanup job.
       const command = new PutObjectCommand({
         Bucket: R2_BUCKET,
         Key: r2Key,
@@ -566,12 +569,16 @@ export async function sessionRoutes(app: FastifyInstance) {
 
       const now = new Date();
 
+      // Compute tracked seconds before stopping (screenshots may be cleaned up later)
+      const trackedSeconds = await getTrackedSeconds(session.id);
+
       const [updated] = await db
         .update(schema.sessions)
         .set({
           status: "stopped",
           stoppedAt: now,
           totalActiveSeconds,
+          trackedSeconds,
           updatedAt: now,
         })
         .where(and(
@@ -595,8 +602,6 @@ export async function sessionRoutes(app: FastifyInstance) {
           .set({ status: "failed", updatedAt: now })
           .where(eq(schema.sessions.id, session.id));
       }
-
-      const trackedSeconds = await getTrackedSeconds(session.id);
 
       return {
         status: "stopped" as const,
@@ -626,7 +631,8 @@ export async function sessionRoutes(app: FastifyInstance) {
       const session = await findSession(request.params.token);
       if (!session) return reply.code(404).send({ error: "Session not found" });
 
-      const trackedSeconds = await getTrackedSeconds(session.id);
+      const liveTrackedSeconds = await getTrackedSeconds(session.id);
+      const trackedSeconds = session.trackedSeconds ?? liveTrackedSeconds;
 
       const baseUrl = process.env.BASE_URL || "http://localhost:3000";
       return {
@@ -805,11 +811,14 @@ export async function sessionRoutes(app: FastifyInstance) {
           const thumbnailUrl = s.thumbnailR2Key
             ? `${baseUrl}/api/media/${s.id}/thumbnail.jpg`
             : null;
+          // Prefer stored trackedSeconds (survives screenshot cleanup),
+          // fall back to live screenshot count for active sessions
+          const trackedSeconds = s.trackedSeconds ?? c.trackedSeconds;
           return {
             token: s.token,
             name: s.name,
             status: s.status,
-            trackedSeconds: c.trackedSeconds,
+            trackedSeconds,
             screenshotCount: c.screenshotCount,
             startedAt: s.startedAt?.toISOString() ?? null,
             createdAt: s.createdAt.toISOString(),

--- a/packages/worker/src/schema.ts
+++ b/packages/worker/src/schema.ts
@@ -38,6 +38,7 @@ export const sessions = pgTable(
     lastScreenshotAt: timestamp("last_screenshot_at", { withTimezone: true }),
     resumedAt: timestamp("resumed_at", { withTimezone: true }),
     totalActiveSeconds: integer("total_active_seconds").notNull().default(0),
+    trackedSeconds: integer("tracked_seconds"),
     videoUrl: text("video_url"),
     videoR2Key: text("video_r2_key"),
     videoWebmUrl: text("video_webm_url"),


### PR DESCRIPTION
trackedSeconds was recalculated from screenshots at query time, but screenshots are deleted after retention period, causing all old sessions to show 0 seconds. Now stored on the session row at stop time.

Backfills existing sessions using totalActiveSeconds as approximation. Also: restrict localhost CORS to dev, clean up orphaned R2 objects.