### PR TITLE
Fix gallery crash when user has >100 tokens

### DIFF
--- a/clients/react/src/hooks/useGallery.ts
+++ b/clients/react/src/hooks/useGallery.ts
@@ -59,18 +59,28 @@ export function useGallery({ apiBaseUrl, tokens }: UseGalleryOptions): UseGaller
       setLoading(true);
     }
 
-    fetch(`${apiBaseUrl}/api/sessions/batch`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ tokens: validTokens }),
-    })
-      .then(async (res) => {
-        if (!res.ok) {
-          const text = await res.text().catch(() => "");
-          throw new Error(`HTTP ${res.status} ${res.statusText}\n${text.slice(0, 500)}`);
-        }
-        return res.json();
-      })
+    const BATCH_SIZE = 100;
+    const chunks: string[][] = [];
+    for (let i = 0; i < validTokens.length; i += BATCH_SIZE) {
+      chunks.push(validTokens.slice(i, i + BATCH_SIZE));
+    }
+
+    Promise.all(
+      chunks.map((chunk) =>
+        fetch(`${apiBaseUrl}/api/sessions/batch`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ tokens: chunk }),
+        }).then(async (res) => {
+          if (!res.ok) {
+            const text = await res.text().catch(() => "");
+            throw new Error(`HTTP ${res.status} ${res.statusText}\n${text.slice(0, 500)}`);
+          }
+          return res.json() as Promise<{ sessions: SessionSummary[] }>;
+        })
+      )
+    )
+      .then((results) => ({ sessions: results.flatMap((r) => r.sessions ?? []) }))
       .then((data: { sessions: SessionSummary[] }) => {
         if (!cancelled) {
           const now = Date.now();


### PR DESCRIPTION
## Summary

- The `/api/sessions/batch` endpoint enforces `maxItems: 100` via JSON schema validation
- `useGallery` was sending all tokens in a single request — any user with >100 stored tokens got a `400` response, making the desktop app fail to load entirely
- Fix: chunk `validTokens` into batches of 100 and fire them in parallel with `Promise.all`, then flatten the results before the existing merge/cache logic

## Test plan

- [ ] User with ≤100 tokens: gallery loads as before (single request, no change in behavior)
- [ ] User with >100 tokens: gallery loads correctly (multiple parallel requests, results merged)
- [ ] Component unmount mid-fetch: `cancelled` flag still prevents stale state updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)