### PR TITLE
change libsoup dependency

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -187,7 +187,7 @@ jobs:
                 echo "depend = glib2" >> .PKGINFO
                 echo "depend = gtk3" >> .PKGINFO
                 echo "depend = hicolor-icon-theme" >> .PKGINFO
-                echo "depend = libsoup" >> .PKGINFO
+                echo "depend = libsoup3" >> .PKGINFO
                 echo "depend = pango" >> .PKGINFO
                 echo "depend = webkit2gtk-4.1" >> .PKGINFO
                 


### PR DESCRIPTION
libsoup seems to be able to be replaced by libsoup3 without affecting functionality. libsoup is a package that exists in the AUR, while libsoup3 exists in the extra repository. with libsoup listed as a dependency, installing will normally result in an error, as the dependency will not be able to be successfully resolved.


Edit: although libsoup may be a legacy dependency, I cannot verify that the application works at all due to failures with other parts, closing.