### PR TITLE
Add JA4 TLS fingerprint telemetry per screenshot

### DIFF
--- a/packages/server/drizzle/0014_early_dazzler.sql
+++ b/packages/server/drizzle/0014_early_dazzler.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "screenshots" ADD COLUMN "ja4" text;

--- a/packages/server/drizzle/meta/0014_snapshot.json
+++ b/packages/server/drizzle/meta/0014_snapshot.json
@@ -1,0 +1,665 @@
+{
+  "id": "473364e1-e955-4325-a01d-ce45da4902e9",
+  "prevId": "b7f35397-13f7-4a5c-8894-6ec9e5725ec0",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.announcements": {
+      "name": "announcements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "level": {
+          "name": "level",
+          "type": "announcement_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'info'"
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "program_id": {
+          "name": "program_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "api_keys_program_id_programs_id_fk": {
+          "name": "api_keys_program_id_programs_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "programs",
+          "columnsFrom": [
+            "program_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_name_unique": {
+          "name": "api_keys_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        },
+        "api_keys_key_unique": {
+          "name": "api_keys_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.programs": {
+      "name": "programs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_session_url": {
+          "name": "new_session_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "programs_name_unique": {
+          "name": "programs_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.screenshots": {
+      "name": "screenshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "r2_key": {
+          "name": "r2_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_at": {
+          "name": "requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "minute_bucket": {
+          "name": "minute_bucket",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confirmed": {
+          "name": "confirmed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_size_bytes": {
+          "name": "file_size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sampled": {
+          "name": "sampled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_info": {
+          "name": "client_info",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ja4": {
+          "name": "ja4",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credited_seconds": {
+          "name": "credited_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expected_at": {
+          "name": "expected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_screenshots_session_id": {
+          "name": "idx_screenshots_session_id",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_screenshots_session_bucket": {
+          "name": "idx_screenshots_session_bucket",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "minute_bucket",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_screenshots_unconfirmed": {
+          "name": "idx_screenshots_unconfirmed",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "confirmed = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_screenshots_session_captured_at": {
+          "name": "idx_screenshots_session_captured_at",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "captured_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "screenshots_session_id_sessions_id_fk": {
+          "name": "screenshots_session_id_sessions_id_fk",
+          "tableFrom": "screenshots",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "program": {
+          "name": "program",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "program_id": {
+          "name": "program_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "session_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stopped_at": {
+          "name": "stopped_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paused_at": {
+          "name": "paused_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_screenshot_at": {
+          "name": "last_screenshot_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resumed_at": {
+          "name": "resumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_active_seconds": {
+          "name": "total_active_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "tracked_seconds": {
+          "name": "tracked_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tracking_mode": {
+          "name": "tracking_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'bucket'"
+        },
+        "streak_anchor_at": {
+          "name": "streak_anchor_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "streak_credited_count": {
+          "name": "streak_credited_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "screenshots_purged_at": {
+          "name": "screenshots_purged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "video_url": {
+          "name": "video_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "video_r2_key": {
+          "name": "video_r2_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail_url": {
+          "name": "thumbnail_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail_r2_key": {
+          "name": "thumbnail_r2_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "compile_attempts": {
+          "name": "compile_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_sessions_status": {
+          "name": "idx_sessions_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sessions_active_last_screenshot": {
+          "name": "idx_sessions_active_last_screenshot",
+          "columns": [
+            {
+              "expression": "last_screenshot_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "status IN ('active', 'paused', 'pending')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_program_id_programs_id_fk": {
+          "name": "sessions_program_id_programs_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "programs",
+          "columnsFrom": [
+            "program_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.announcement_level": {
+      "name": "announcement_level",
+      "schema": "public",
+      "values": [
+        "info",
+        "success",
+        "warning",
+        "danger"
+      ]
+    },
+    "public.session_status": {
+      "name": "session_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "active",
+        "paused",
+        "stopped",
+        "compiling",
+        "complete",
+        "failed"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/server/drizzle/meta/_journal.json
+++ b/packages/server/drizzle/meta/_journal.json
@@ -99,6 +99,13 @@
       "when": 1781480504163,
       "tag": "0013_announcements",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1784770755102,
+      "tag": "0014_early_dazzler",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -166,6 +166,17 @@ export const screenshots = pgTable(
     // existed or when the client sent nothing. The session's "first recorded"
     // clientInfo is derived from the earliest row that has one.
     clientInfo: text("client_info"),
+    // JA4 TLS client fingerprint of the connection that made the upload-url
+    // request. Unlike clientInfo (client-supplied and freely spoofable) this is
+    // observed at the TLS layer, so it's a harder-to-forge abuse signal: a
+    // genuine Lookout client has a stable JA4, and it drifting mid-session (or
+    // disagreeing with the claimed clientInfo) is suspicious. The Node origin
+    // can't compute JA4 — it's set by the edge proxy (e.g. a Cloudflare
+    // Transform Rule from `cf.bot_management.ja4`) as a request header and read
+    // via JA4_HEADER. Stored opaquely. NULL when the header is absent (local
+    // dev, direct-to-origin) or predates this column. Like clientInfo, the
+    // session's "first recorded" JA4 is the earliest row that has one.
+    ja4: text("ja4"),
     // Credit-mode only. 0 or 60. NULL for bucket-mode rows.
     creditedSeconds: integer("credited_seconds"),
     // Credit-mode only. Server-predicted capture time at confirm; lets us

--- a/packages/server/src/lib/ja4.ts
+++ b/packages/server/src/lib/ja4.ts
@@ -1,0 +1,46 @@
+import type { FastifyRequest } from "fastify";
+import { JA4_MAX_BYTES } from "@lookout/shared";
+
+/**
+ * Which request header carries the JA4 TLS fingerprint. The Node origin can't
+ * compute JA4 itself (it terminates plain HTTP behind a proxy), so the edge is
+ * expected to observe the ClientHello and forward it here — e.g. a Cloudflare
+ * Transform Rule that sets this header from `cf.bot_management.ja4`.
+ *
+ * Configurable so the header name can match whatever the deployment's edge
+ * emits. Lower-cased once at load; Fastify/Node header keys are always lower.
+ * Absent config → default `cf-ja4`, matching our Cloudflare Transform Rule
+ * (`CF-JA4 = cf.bot_management.ja4`).
+ */
+const JA4_HEADER = (process.env.JA4_HEADER || "cf-ja4").toLowerCase();
+
+// A canonical JA4 is printable ASCII with a small alphabet (hex + a/b/c/d/i/q/t
+// markers and underscores), e.g. "t13d1516h2_8daaf6152771_b186095e22b6". We
+// don't enforce the exact grammar — JA4 has siblings (JA4H/JA4S/…) and the
+// spec evolves — but we do reject anything with characters no JA4 variant uses,
+// so a garbage/injected header value degrades to null rather than being stored.
+const JA4_SHAPE = /^[A-Za-z0-9._-]+$/;
+
+/**
+ * Best-effort sanitize of a raw header value into a stored JA4, mirroring how
+ * `clientInfo` is handled: trim, bound the length, and drop anything malformed
+ * instead of rejecting the request. Returns null for missing/empty/oversized/
+ * malformed input so the upload still succeeds without a fingerprint.
+ */
+export function sanitizeJa4(raw: string | undefined | null): string | null {
+  if (!raw) return null;
+  const v = raw.trim();
+  if (!v || v.length > JA4_MAX_BYTES || !JA4_SHAPE.test(v)) return null;
+  return v;
+}
+
+/**
+ * Pull the JA4 fingerprint off an incoming request's edge-set header. A header
+ * sent more than once arrives as an array; take the first. Returns null when
+ * the header is absent (local dev, direct-to-origin) or malformed.
+ */
+export function extractJa4(request: FastifyRequest): string | null {
+  const h = request.headers[JA4_HEADER];
+  const raw = Array.isArray(h) ? h[0] : h;
+  return sanitizeJa4(raw);
+}

--- a/packages/server/src/routes/internal.ts
+++ b/packages/server/src/routes/internal.ts
@@ -123,6 +123,19 @@ export async function internalRoutes(app: FastifyInstance) {
         )
         .orderBy(sql`${schema.screenshots.requestedAt} ASC`)
         .limit(1);
+      // First recorded JA4 TLS fingerprint (edge-observed, resolved
+      // independently of clientInfo). NULL when the edge never set it.
+      const [firstJa4] = await db
+        .select({ ja4: schema.screenshots.ja4 })
+        .from(schema.screenshots)
+        .where(
+          and(
+            eq(schema.screenshots.sessionId, sessionId),
+            isNotNull(schema.screenshots.ja4),
+          ),
+        )
+        .orderBy(sql`${schema.screenshots.requestedAt} ASC`)
+        .limit(1);
       return {
         session: {
           ...sessionData,
@@ -136,6 +149,7 @@ export async function internalRoutes(app: FastifyInstance) {
         trackedSeconds,
         screenshotCount: Number(confirmedCount),
         clientInfo: firstClient?.clientInfo ?? null,
+        ja4: firstJa4?.ja4 ?? null,
       };
     },
   );

--- a/packages/server/src/routes/sessions.ts
+++ b/packages/server/src/routes/sessions.ts
@@ -14,6 +14,7 @@ import {
   validateCapturedAt,
 } from "../lib/timing.js";
 import { now } from "../lib/clock.js";
+import { extractJa4 } from "../lib/ja4.js";
 import {
   SCREENSHOT_INTERVAL_MS,
   PRESIGNED_URL_EXPIRY_SECONDS,
@@ -109,6 +110,26 @@ async function getFirstClientInfo(sessionId: string): Promise<string | null> {
   return row?.clientInfo ?? null;
 }
 
+/** First recorded JA4 TLS fingerprint for a session — the ja4 on the earliest
+ *  screenshot row that has one. Same "first recorded" rule as
+ *  {@link getFirstClientInfo}, but resolved independently (a row may carry one
+ *  telemetry field without the other). NULL when the edge never set the JA4
+ *  header for this session. */
+async function getFirstJa4(sessionId: string): Promise<string | null> {
+  const [row] = await db
+    .select({ ja4: schema.screenshots.ja4 })
+    .from(schema.screenshots)
+    .where(
+      and(
+        eq(schema.screenshots.sessionId, sessionId),
+        isNotNull(schema.screenshots.ja4),
+      ),
+    )
+    .orderBy(sql`${schema.screenshots.requestedAt} ASC`)
+    .limit(1);
+  return row?.ja4 ?? null;
+}
+
 /** Count total upload-url requests (confirmed + unconfirmed) */
 async function getTotalUploadRequests(sessionId: string): Promise<number> {
   const [{ count }] = await db
@@ -142,6 +163,7 @@ export async function sessionRoutes(app: FastifyInstance) {
       const liveTrackedSeconds = await getTrackedSecondsForSession(session);
       const screenshotCount = await getScreenshotCount(session.id);
       const clientInfo = await getFirstClientInfo(session.id);
+      const ja4 = await getFirstJa4(session.id);
       // Prefer stored value (survives screenshot cleanup), fall back to live count.
       // For credit mode, both paths read sessions.tracked_seconds so they match.
       const trackedSeconds =
@@ -156,6 +178,7 @@ export async function sessionRoutes(app: FastifyInstance) {
         trackedSeconds,
         screenshotCount,
         clientInfo,
+        ja4,
         startedAt: session.startedAt?.toISOString() ?? null,
         totalActiveSeconds: session.totalActiveSeconds,
         createdAt: session.createdAt.toISOString(),
@@ -437,6 +460,11 @@ export async function sessionRoutes(app: FastifyInstance) {
       const clientInfo =
         request.query.clientInfo?.trim().slice(0, CLIENT_INFO_MAX_BYTES) || null;
 
+      // JA4 TLS fingerprint observed at the edge and forwarded as a header
+      // (see lib/ja4). Unlike clientInfo it's not client-controllable at the
+      // app layer. NULL when the edge didn't set it (local dev, etc).
+      const ja4 = extractJa4(request);
+
       // Create screenshot record (unconfirmed)
       await db.insert(schema.screenshots).values({
         id: screenshotId,
@@ -447,6 +475,7 @@ export async function sessionRoutes(app: FastifyInstance) {
         confirmed: false,
         capturedAt: rowCapturedAt,
         clientInfo,
+        ja4,
       });
 
       // Generate presigned PUT URL
@@ -1019,6 +1048,7 @@ export async function sessionRoutes(app: FastifyInstance) {
       );
 
       const clientInfo = await getFirstClientInfo(session.id);
+      const ja4 = await getFirstJa4(session.id);
 
       // first/last are convenience accessors on the already-ascending array.
       // NOTE: last − first is NOT capture duration — a paused session has gaps
@@ -1029,6 +1059,7 @@ export async function sessionRoutes(app: FastifyInstance) {
         first: timestamps[0] ?? null,
         last: timestamps[timestamps.length - 1] ?? null,
         clientInfo,
+        ja4,
         timestamps,
       };
     },

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -141,6 +141,13 @@ export const SCREENSHOT_RETENTION_DAYS = 7;
  *  client; real payloads are a few hundred bytes. */
 export const CLIENT_INFO_MAX_BYTES = 1024;
 
+/** Max byte length of a JA4 TLS fingerprint read from the edge-set request
+ *  header (JA4_HEADER). A canonical JA4 is ~36 chars (e.g.
+ *  "t13d1516h2_8daaf6152771_b186095e22b6"); the cap leaves headroom for
+ *  variants while bounding a hostile/misconfigured edge. Longer values are
+ *  ignored (stored as null). */
+export const JA4_MAX_BYTES = 128;
+
 // ──────────────────────────────────────────────────────────
 // Screenshot capture settings
 // ──────────────────────────────────────────────────────────

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -77,6 +77,8 @@ export interface SessionResponse {
   videoWebmUrl?: string | null;
   /** First recorded client telemetry for the session; `null` if none captured. */
   clientInfo?: ClientInfo | null;
+  /** First recorded JA4 TLS fingerprint (edge-observed); `null` if none. */
+  ja4?: string | null;
   metadata: Record<string, unknown>;
 }
 
@@ -89,6 +91,8 @@ export interface TimingsResponse {
   last: string | null;
   /** First recorded client telemetry for the session; `null` if none captured. */
   clientInfo: ClientInfo | null;
+  /** First recorded JA4 TLS fingerprint (edge-observed); `null` if none. */
+  ja4: string | null;
   timestamps: string[];
 }
 


### PR DESCRIPTION
Capture the edge-observed JA4 TLS client fingerprint (Cloudflare's cf-ja4 managed-transform header) on each upload-url request and store it per screenshot, mirroring the existing clientInfo pattern. Unlike clientInfo (client-supplied, freely spoofable) JA4 is observed at the TLS layer, so it's a harder-to-forge abuse signal for spotting sessions whose reported client disagrees with their fingerprint.

- screenshots.ja4 column + migration 0014
- lib/ja4: configurable JA4_HEADER (default cf-ja4), sanitize/validate
- expose first-recorded JA4 on session status, timings, and internal session-detail responses (independent of clientInfo)
- JA4_MAX_BYTES constant + shared type fields
- document JA4_HEADER / Cloudflare setup in .env.example

After deployed, run npm run db:migrate -w packages/server