### PR TITLE
Fix the compile progress ring stalling, and 136MB Linux bundles

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,6 +122,18 @@ jobs:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
           SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+          # `[profile.release] debug = true` in Cargo.toml exists to emit the
+          # Windows .pdb. On MSVC that debug info lands in a SEPARATE file, and
+          # on macOS in a .dSYM outside the .app — but on Linux it is embedded
+          # straight into the ELF. Measured on 0.3.7: a 136MB .deb and .rpm
+          # against a 6MB Windows installer and a 20MB universal macOS dmg.
+          #
+          # Two costs. Linux users download 136MB per update through the
+          # updater, and the rpm bundler spends 76 MINUTES single-threaded
+          # xz-compressing it (06:24:56 -> 07:41:03 on the 0.3.7 build), which
+          # is 85% of a 90-minute job. Turning debug off for Linux only keeps
+          # the .pdb that this setting was added for.
+          CARGO_PROFILE_RELEASE_DEBUG: ${{ runner.os == 'Linux' && 'false' || 'true' }}
 
       - name: Build app (without signing)
         if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
@@ -136,6 +148,18 @@ jobs:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
           SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+          # `[profile.release] debug = true` in Cargo.toml exists to emit the
+          # Windows .pdb. On MSVC that debug info lands in a SEPARATE file, and
+          # on macOS in a .dSYM outside the .app — but on Linux it is embedded
+          # straight into the ELF. Measured on 0.3.7: a 136MB .deb and .rpm
+          # against a 6MB Windows installer and a 20MB universal macOS dmg.
+          #
+          # Two costs. Linux users download 136MB per update through the
+          # updater, and the rpm bundler spends 76 MINUTES single-threaded
+          # xz-compressing it (06:24:56 -> 07:41:03 on the 0.3.7 build), which
+          # is 85% of a 90-minute job. Turning debug off for Linux only keeps
+          # the .pdb that this setting was added for.
+          CARGO_PROFILE_RELEASE_DEBUG: ${{ runner.os == 'Linux' && 'false' || 'true' }}
 
       - name: Build Arch Linux package (.pkg.tar.zst)
         if: runner.os == 'Linux'

--- a/clients/desktop/src-tauri/Cargo.toml
+++ b/clients/desktop/src-tauri/Cargo.toml
@@ -5,8 +5,15 @@ opt-level = 3
 opt-level = 1
 
 # Emit debug info (.pdb on MSVC) for release builds so crash offsets can be
-# symbolized. Does not change codegen/optimization; debug info ships only in the
-# separate .pdb, never in the released binary.
+# symbolized. Does not change codegen/optimization.
+#
+# PLATFORM CAVEAT — the reason release.yml overrides this for Linux. Debug info
+# lands in a separate file only on MSVC (.pdb) and macOS (.dSYM, outside the
+# .app). On Linux it is embedded directly in the ELF, which made the 0.3.7
+# bundles 136MB against a 6MB Windows installer, and cost 76 minutes of
+# single-threaded xz in the rpm bundler — 85% of the Linux job. So the workflow
+# sets CARGO_PROFILE_RELEASE_DEBUG=false on Linux; if you build a Linux release
+# by hand and care about size, do the same.
 [profile.release]
 debug = true
 

--- a/clients/react/src/components/TimelapseEditor.tsx
+++ b/clients/react/src/components/TimelapseEditor.tsx
@@ -27,7 +27,12 @@ import {
   type UnitRegion,
 } from "../hooks/editorMath.js";
 import { useEditLease } from "../hooks/useEditLease.js";
-import { compileEstimateMs, estimateBuildProgress } from "../hooks/buildProgress.js";
+import {
+  compileEstimateMs,
+  estimateBuildProgress,
+  interpolateBuildProgress,
+  PROGRESS_CAP,
+} from "../hooks/buildProgress.js";
 import { injectEditorStyles } from "./editorStyles.js";
 import { Button } from "../ui/Button.js";
 import { MinutesFlow } from "../ui/MinutesFlow.js";
@@ -133,8 +138,11 @@ export function TimelapseEditor({
   /** Real compile progress from /status, when the worker reports it; null
    *  until the first metered poll (or forever, for cut-apply/old workers). */
   const [realProgress, setRealProgress] = useState<number | null>(null);
-  /** Once true, real progress owns the ring and the time estimate stands down. */
-  const sawRealRef = useRef(false);
+  /** Latest real value and when it landed. Real progress ANCHORS the ring
+   *  rather than owning it outright: it arrives once per 2s poll and only when
+   *  the worker has moved another 1%, so displaying it directly lurches in
+   *  steps with long dead pauses. The tick eases between anchors. */
+  const realAnchorRef = useRef<{ value: number; atMs: number } | null>(null);
   /** Anchored once per preparing spell, so even a genuine change in the
    *  unit count can't restart the estimate. */
   const prepareStartRef = useRef<number | null>(null);
@@ -250,7 +258,7 @@ export function TimelapseEditor({
   // waited would be worse than none.
   useEffect(() => {
     if (realProgress === null) return;
-    sawRealRef.current = true;
+    realAnchorRef.current = { value: realProgress, atMs: Date.now() };
     setBuildProgress((prev) => Math.max(prev, realProgress));
   }, [realProgress]);
   useEffect(() => {
@@ -262,10 +270,31 @@ export function TimelapseEditor({
     const startedAt = prepareStartRef.current;
     const estimateMs = compileEstimateMs(preparingUnits);
     const tick = () => {
-      // Ground truth, once it arrives, owns the ring.
-      if (sawRealRef.current) return;
-      const next = estimateBuildProgress(Date.now() - startedAt, estimateMs);
-      setBuildProgress((prev) => Math.max(prev, next));
+      // BOTH sources run, and the ring takes whichever is further along.
+      // Neither may switch the other off, and that is the whole trick:
+      //
+      //  - The estimate is a continuous function of time, so something is
+      //    always moving at every 200ms tick — the ring can never sit still.
+      //    Letting real progress silence it is what made this feel like a
+      //    hang: updates dropped to one per 2s poll, in >=1% steps.
+      //  - Real worker progress pulls the ring UP whenever the compile is
+      //    further along than the guess, so the number stays tied to truth
+      //    instead of drifting off on a curve.
+      //  - Easing out of the last real anchor keeps the gaps between polls
+      //    smooth, bounded by what one poll is expected to deliver.
+      //
+      // Monotonic via `prev`, and capped short of 100% — only the status flip
+      // ends the wait, so a full ring while the user is still waiting would
+      // be a lie.
+      const now = Date.now();
+      const anchor = realAnchorRef.current;
+      const estimated = estimateBuildProgress(now - startedAt, estimateMs);
+      const fromReal = anchor
+        ? interpolateBuildProgress(anchor.value, now - anchor.atMs, estimateMs)
+        : 0;
+      setBuildProgress((prev) =>
+        Math.min(PROGRESS_CAP, Math.max(prev, estimated, fromReal)),
+      );
     };
     tick();
     const id = setInterval(tick, 200);

--- a/clients/react/src/hooks/buildProgress.test.ts
+++ b/clients/react/src/hooks/buildProgress.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { estimateBuildProgress } from "./buildProgress.js";
+import {
+  estimateBuildProgress,
+  interpolateBuildProgress,
+  PROGRESS_POLL_MS,
+  PROGRESS_CAP,
+  COMPILE_MS_PER_UNIT,
+} from "./buildProgress.js";
 
 describe("estimateBuildProgress", () => {
   const estimate = 30_000;
@@ -41,5 +47,126 @@ describe("estimateBuildProgress", () => {
     const short = estimateBuildProgress(20_000, 20_000);
     const long = estimateBuildProgress(20_000, 200_000);
     expect(long).toBeLessThan(short);
+  });
+});
+
+describe("interpolateBuildProgress", () => {
+  const estimate = 30_000;
+
+  it("keeps moving between polls instead of freezing", () => {
+    // The bug: once real progress arrived the ring froze between polls, so it
+    // went from five updates a second to one every two seconds and read as a
+    // hang. Every 200ms tick must show movement.
+    const a = interpolateBuildProgress(0.4, 0, estimate);
+    const b = interpolateBuildProgress(0.4, 200, estimate);
+    const c = interpolateBuildProgress(0.4, 400, estimate);
+    expect(b).toBeGreaterThan(a);
+    expect(c).toBeGreaterThan(b);
+  });
+
+  it("never advances more than one poll interval is expected to deliver", () => {
+    // Honesty bound: if the worker stalls, the ring eases to just short of the
+    // next anchor and holds — it can't sail to the cap while nothing happens.
+    const budget = PROGRESS_POLL_MS / estimate;
+    for (const stalled of [2_000, 10_000, 60_000, 600_000]) {
+      const p = interpolateBuildProgress(0.4, stalled, estimate);
+      expect(p).toBeLessThanOrEqual(0.4 + budget + 1e-9);
+    }
+  });
+
+  it("holds rather than inflating on a long stall", () => {
+    const at10s = interpolateBuildProgress(0.4, 10_000, estimate);
+    const at10m = interpolateBuildProgress(0.4, 600_000, estimate);
+    expect(at10m - at10s).toBeLessThan(0.001);
+  });
+
+  it("never passes the cap, however late the anchor is", () => {
+    expect(interpolateBuildProgress(PROGRESS_CAP, 600_000, estimate)).toBe(PROGRESS_CAP);
+    expect(interpolateBuildProgress(0.99, 600_000, estimate)).toBeLessThanOrEqual(PROGRESS_CAP);
+    expect(interpolateBuildProgress(0.94, 600_000, estimate)).toBeLessThanOrEqual(PROGRESS_CAP);
+  });
+
+  it("starts exactly at the anchor, so a new real value never rewinds it", () => {
+    expect(interpolateBuildProgress(0.62, 0, estimate)).toBeCloseTo(0.62, 10);
+  });
+
+  it("moves more slowly for a longer compile", () => {
+    // A poll interval is a smaller share of a long build, so the same 200ms
+    // should carry the ring less far.
+    const short = interpolateBuildProgress(0.4, 200, 10_000);
+    const long = interpolateBuildProgress(0.4, 200, 300_000);
+    expect(long).toBeLessThan(short);
+  });
+
+  it("clamps a nonsensical anchor rather than propagating it", () => {
+    expect(interpolateBuildProgress(-1, 1_000, estimate)).toBeGreaterThanOrEqual(0);
+    expect(interpolateBuildProgress(5, 1_000, estimate)).toBeLessThanOrEqual(PROGRESS_CAP);
+  });
+});
+
+/**
+ * The two sources together — the property the user actually experiences.
+ * Neither source may silence the other: the estimate guarantees the ring is
+ * always moving, real progress guarantees it stays tied to the truth.
+ */
+describe("the ring never stalls and never lies", () => {
+  const estimateMs = 6_000 + 120 * COMPILE_MS_PER_UNIT;
+  /** Mirrors the editor's tick. */
+  const display = (
+    prev: number,
+    elapsedMs: number,
+    anchor: { value: number; atMs: number } | null,
+    nowMs: number,
+  ) =>
+    Math.min(
+      PROGRESS_CAP,
+      Math.max(
+        prev,
+        estimateBuildProgress(elapsedMs, estimateMs),
+        anchor ? interpolateBuildProgress(anchor.value, nowMs - anchor.atMs, estimateMs) : 0,
+      ),
+    );
+
+  it("moves on EVERY tick, even while real progress is stuck behind", () => {
+    // The failure mode: real progress lands below the estimate, and a
+    // ring driven only by the anchor would sit frozen until real caught up.
+    let prev = 0;
+    const anchor = { value: 0.02, atMs: 0 };
+    let stalls = 0;
+    for (let t = 200; t <= 8_000; t += 200) {
+      const next = display(prev, t, anchor, t);
+      if (next <= prev) stalls++;
+      prev = next;
+    }
+    expect(stalls).toBe(0);
+  });
+
+  it("is pulled up by real progress when the worker is ahead of the guess", () => {
+    const early = 1_000;
+    const withoutReal = display(0, early, null, early);
+    const withReal = display(0, early, { value: 0.7, atMs: early }, early);
+    expect(withReal).toBeGreaterThan(withoutReal);
+    expect(withReal).toBeCloseTo(0.7, 2);
+  });
+
+  it("is monotonic across a full wait, whatever the sources do", () => {
+    let prev = 0;
+    let anchor: { value: number; atMs: number } | null = null;
+    for (let t = 0; t <= 40_000; t += 200) {
+      // Real progress arrives every 2s, jitters, and even regresses once.
+      if (t > 0 && t % 2_000 === 0) {
+        const v = t === 10_000 ? 0.1 : Math.min(0.95, (t / 40_000) * 0.95);
+        anchor = { value: v, atMs: t };
+      }
+      const next = display(prev, t, anchor, t);
+      expect(next).toBeGreaterThanOrEqual(prev);
+      prev = next;
+    }
+  });
+
+  it("never shows a full ring while the user is still waiting", () => {
+    const late = display(0.94, 10 * 60_000, { value: 0.95, atMs: 0 }, 10 * 60_000);
+    expect(late).toBeLessThanOrEqual(PROGRESS_CAP);
+    expect(late).toBeLessThan(1);
   });
 });

--- a/clients/react/src/hooks/buildProgress.ts
+++ b/clients/react/src/hooks/buildProgress.ts
@@ -2,8 +2,16 @@
 export const COMPILE_BASE_MS = 6_000;
 
 /** Marginal cost per capture unit (download + a 1s segment encode, across
- *  the worker's 8-way pool). Only used to size the estimate below. */
-export const COMPILE_MS_PER_UNIT = 350;
+ *  the worker's 8-way pool). Only used to size the estimate below.
+ *
+ *  Was 350, calibrated against the single-pass full-quality compile. The
+ *  editor now waits on the PREVIEW tier, measured at ~83ms of encode per unit
+ *  against ~431ms for the publish tier — so across an 8-way pool the marginal
+ *  wall-clock cost is tens of milliseconds, dominated by the R2 fetch rather
+ *  than ffmpeg. Leaving it at 350 made the estimate ~4x too slow, so real
+ *  worker progress immediately overtook it and the ring inherited the poll's
+ *  2-second granularity for the whole wait. */
+export const COMPILE_MS_PER_UNIT = 90;
 
 /** How long a compile of `units` minutes of footage is expected to take. */
 export function compileEstimateMs(units: number): number {
@@ -28,4 +36,50 @@ export function compileEstimateMs(units: number): number {
 export function estimateBuildProgress(elapsedMs: number, estimateMs: number): number {
   if (estimateMs <= 0) return 0;
   return 1 - Math.exp(-2.2 * (Math.max(0, elapsedMs) / estimateMs));
+}
+
+/** How often the editor polls `/status` for real progress. */
+export const PROGRESS_POLL_MS = 2_000;
+
+/** Ceiling on reported progress. Mirrors the worker's PROGRESS_UNIT_CAP: the
+ *  unit loop is the only metered stage, so assembly, thumbnail and upload
+ *  still run after it finishes. Only the status flip ends the wait. */
+export const PROGRESS_CAP = 0.95;
+
+/**
+ * Progress BETWEEN real worker updates.
+ *
+ * Real progress arrives once per `/status` poll — every 2s, and only when the
+ * worker has moved a further 1% — so using it directly makes the number lurch
+ * in coarse steps with long dead pauses. Freezing the estimate the moment the
+ * first real value lands (the original behaviour) was worse still: the ring
+ * went from updating five times a second to once every two seconds, which read
+ * as the whole editor hanging.
+ *
+ * So a real value becomes an ANCHOR and this eases forward from it, with two
+ * bounds that keep it honest:
+ *
+ *  - It may only advance by as much as one poll interval is expected to
+ *    deliver. If the worker stalls, the number eases up to just short of the
+ *    next anchor and HOLDS there — it can't sail off to the cap while nothing
+ *    is happening.
+ *  - It never passes PROGRESS_CAP.
+ *
+ * Same shape as useSessionTimer's interpolation between server credits, and
+ * for the same reason: a value that only moves when the network says so looks
+ * broken, and a value that runs ahead of the truth lies.
+ */
+export function interpolateBuildProgress(
+  anchor: number,
+  sinceAnchorMs: number,
+  estimateMs: number,
+): number {
+  const from = Math.max(0, Math.min(PROGRESS_CAP, anchor));
+  if (estimateMs <= 0) return from;
+  // What one poll interval's worth of work is expected to be, as a fraction
+  // of the whole compile — and never more headroom than remains.
+  const budget = Math.min(PROGRESS_CAP - from, PROGRESS_POLL_MS / estimateMs);
+  if (budget <= 0) return from;
+  const eased = 1 - Math.exp(-2.2 * (Math.max(0, sinceAnchorMs) / PROGRESS_POLL_MS));
+  return Math.min(PROGRESS_CAP, from + budget * eased);
 }


### PR DESCRIPTION
Two follow-ups to #167, both found while testing the release in prod.

## The compile ring stalled once real progress arrived

Symptom: the "Preparing your timelapse" percentage was smooth for the first
couple of seconds, then crawled.

Two causes.

The first real `/status` value set a flag that switched the time estimate off
permanently. From that moment the only thing that could move the number was a
poll — every 2s, and only when the worker had advanced another 1% (its write
threshold), stopping dead at its 0.95 cap. Five updates a second became one
every two seconds in coarse steps, which reads as a hang.

The second came from #167 itself: `COMPILE_MS_PER_UNIT` was 350, calibrated
against the single-pass full-quality compile. The editor now waits on the
*preview* tier — ~83ms of encode per unit against ~431ms for publish, and across
an 8-way pool the marginal cost is dominated by the R2 fetch. At 350 the
estimate ran ~4x too slow, so real progress overtook it immediately and the ring
inherited the poll's granularity for the whole wait. Now 90.

The fix: neither source may silence the other. Both run every tick and the ring
takes whichever is further along.

- The estimate is continuous in time, so something is always moving and the ring
  can never sit still.
- Real worker progress pulls it up whenever the compile is ahead of the guess,
  so the number stays tied to the truth.
- Between polls it eases out of the last real anchor, bounded by what one poll
  interval is expected to deliver — a stalled worker eases to just short of the
  next anchor and holds, rather than sailing to the cap.

Also capped at 0.95 instead of asymptoting toward 1. A ring sitting at 99% is
what made a genuinely stuck compile indistinguishable from a slow one — which
happened in prod this week.

Tests assert the properties rather than the numbers: it moves on every tick even
while real progress lags behind, it's pulled up when the worker is ahead, it
stays monotonic through jittering and even regressing anchors, and it never
shows a full ring while the wait continues.

## Linux bundles carried embedded debug info

The Linux release job took 90 minutes on x64 and 142 on arm64, against 16-22 for
Windows and macOS. 76 of those minutes were a single step: the rpm bundler
xz-compressing single-threaded, 06:24:56 -> 07:41:03 on the 0.3.7 build. The
Rust compile was 9m26s and the `.deb` took 13 seconds.

Cause is `debug = true` in `[profile.release]`, added in 0.3.5 to emit the
Windows `.pdb` — which is exactly when the Linux job went from 12.8 minutes
(0.3.4) to 99 (0.3.5). Its comment claimed debug info "ships only in the
separate .pdb, never in the released binary". True on MSVC, and on macOS it goes
to a `.dSYM` outside the `.app`, but on Linux it is embedded straight into the
ELF. The 0.3.7 release assets show it:

| asset | size |
| --- | --- |
| Linux `.deb` / `.rpm` | 136 MB |
| Arch `.pkg.tar.zst` | 125 MB |
| macOS `.dmg` (**universal**, 2 arches) | 20 MB |
| Windows `.exe` | 6 MB |

CI time was the visible half. The other half is that Linux users pull 136 MB
through the updater on every release.

`release.yml` now sets `CARGO_PROFILE_RELEASE_DEBUG=false` on the Linux legs
only, so Windows keeps the `.pdb` this setting exists for and macOS keeps its
`.dSYM`. The Cargo.toml comment is corrected, since believing it is what kept
this hidden.

## Verification

95 react tests pass; typecheck clean.

The bundle-size and CI-duration numbers above are measured from the 0.3.7 build.
The improvement is **predicted, not verified** — it can't be confirmed until the
next tagged build. Expect Linux bundles around 10-15MB and the job back near its
0.3.4 duration.

## Note on the v0.3.7 release

The existing `v0.3.7` draft carries the 136 MB Linux assets. Worth re-cutting
after this lands rather than publishing as-is, which also confirms the Linux
duration for free.
